### PR TITLE
イベント詳細でマークダウン記法を使えるようにする

### DIFF
--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Event;
 use Illuminate\Http\Request;
+use Illuminate\Mail\Markdown;
 
 class EventController extends Controller
 {
@@ -35,6 +36,9 @@ class EventController extends Controller
     public function details($id)
     {
         $event = Event::findOrFail($id);
-        return view('event.details', ['event' => $event]);
+        $detail_markdown = Markdown::parse(e($event->details));
+
+
+        return view('event.details', ['event' => $event, 'detail_markdown' => $detail_markdown]);
     }
 }

--- a/resources/views/components/textarea.blade.php
+++ b/resources/views/components/textarea.blade.php
@@ -1,0 +1,5 @@
+@props(['disabled' => false])
+
+<textarea {{ $disabled ? 'disabled' : '' }} {!! $attributes->merge(['class' => 'border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 rounded-md shadow-sm']) !!}>
+{{ $value ?? $slot }}
+</textarea>

--- a/resources/views/event/details.blade.php
+++ b/resources/views/event/details.blade.php
@@ -12,7 +12,7 @@
                     @if ($event)
                     <div class="max-w-xl">
                         <h1>{{ $event->name }}</h1>
-                        <p>{{ $event->details }}</p>
+                        <p>{{ $detail_markdown }}</p>
                         <p>{{ $event->category }}</p>
                         <p>{{ $event->tag }}</p>
                         <p>{{ $event->conditions_of_participation }}</p>

--- a/resources/views/event/partials/create-event-form.blade.php
+++ b/resources/views/event/partials/create-event-form.blade.php
@@ -25,7 +25,7 @@
 
         <div>
             <x-input-label for="details" :value="__('Details')" />
-            <x-text-input id="details" name="details" type="text" class="mt-1 block w-full" :value="old('details', '')" required autofocus autocomplete="details" />
+            <x-textarea id="details" name="details" type="text" class="mt-1 block w-full" :value="old('details', '')" required autofocus autocomplete="details" />
             <x-input-error class="mt-2" :messages="$errors->get('details')" />
         </div>
 


### PR DESCRIPTION
## 対応したISSUE
- close #ISSUE_NUMBER

## 概要
- 個人的要望
- マークダウン記法使えたらな。
- できればプレビューもあれば嬉しい。
- 現時点でh1, h2タグなどのスタイルが無効になっているため見た目で現れない
- 実際にタグとして出力はされているから動いて入る

## リンク
-

## レビュー箇所
- [x] レビューしてほしい箇所

## スクリーンショット
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="https://github.com/SymbaX/symbax/assets/33868170/6fa266d7-a875-4bd8-9e1d-88b029a44e29" width="300" />


<!-- 変更前のスクリーンショットは可能であれば貼り付ける --> 
