### PR TITLE
eventsテーブルに作成者を保持するカラムを追加

### DIFF
--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Event;
 use Illuminate\Http\Request;
 use Illuminate\Mail\Markdown;
+use Illuminate\Support\Facades\Auth;
 
 class EventController extends Controller
 {
@@ -21,6 +22,8 @@ class EventController extends Controller
             'place' => 'required',
             'number_of_people' => 'required',
         ]);
+
+        $validatedData['creator_id'] = Auth::id();
 
         Event::create($validatedData);
 

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -16,5 +16,6 @@ class Event extends Model
         'datetime',
         'place',
         'number_of_people',
+        'creator_id',
     ];
 }

--- a/database/migrations/2023_06_20_132847_create_events_table.php
+++ b/database/migrations/2023_06_20_132847_create_events_table.php
@@ -22,6 +22,8 @@ return new class extends Migration
             $table->datetime('datetime');
             $table->string('place');
             $table->integer('number_of_people');
+            $table->unsignedBigInteger('creator_id');
+            $table->foreign('creator_id')->references('id')->on('users')->onDelete('cascade');
             $table->timestamps();
         });
     }


### PR DESCRIPTION
## 対応したISSUE
- #88 

## 概要
- eventsテーブルに作成者を保持するカラムを追加
- `->onDelete('cascade');`が付与されているためユーザーが削除されたタイミングでイベントが消える（要検討）

## リンク
-

## レビュー箇所
- [x] レビューしてほしい箇所

## スクリーンショット
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />


<!-- 変更前のスクリーンショットは可能であれば貼り付ける --> 
