### PR TITLE
Upcomingをhomeと統合した

### DIFF
--- a/app/Http/Controllers/Event/EventDeleteController.php
+++ b/app/Http/Controllers/Event/EventDeleteController.php
@@ -42,7 +42,7 @@ class EventDeleteController extends Controller
         $deleted = $this->eventDeleteUseCase->deleteEvent($event_id);
 
         if ($deleted) {
-            return redirect()->route('index.upcoming')->with('status', 'event-deleted');
+            return redirect()->route('index.home')->with('status', 'event-deleted');
         } else {
             return redirect()->route('event.show', ['event_id' => $event_id])->with('status', 'cannot-delete-event');
         }

--- a/app/Http/Controllers/Event/EventListController.php
+++ b/app/Http/Controllers/Event/EventListController.php
@@ -36,10 +36,10 @@ class EventListController extends Controller
      *
      * @return View イベント一覧のビュー
      */
-    public function indexUpcoming(): View
+    public function indexHome(): View
     {
         $events = $this->eventListUseCase->getUpcomingEvents();
-        return view('event.list-upcoming', ['events' => $events]);
+        return view('event.list-home', ['events' => $events]);
     }
 
     /**

--- a/app/Http/Controllers/Event/EventListController.php
+++ b/app/Http/Controllers/Event/EventListController.php
@@ -39,7 +39,8 @@ class EventListController extends Controller
     public function indexHome(): View
     {
         $events = $this->eventListUseCase->getUpcomingEvents();
-        return view('event.list-home', ['events' => $events]);
+        $newest_events = $this->eventListUseCase->getNewestEvents();
+        return view('event.list-home', ['events' => $events, 'newest_events' => $newest_events]);
     }
 
     /**

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -17,7 +17,7 @@ class RouteServiceProvider extends ServiceProvider
      *
      * @var string
      */
-    public const HOME = '/upcoming';
+    public const HOME = '/home';
 
     /**
      * Define your route model bindings, pattern filters, and other route configuration.

--- a/app/UseCases/Event/EventListUseCase.php
+++ b/app/UseCases/Event/EventListUseCase.php
@@ -30,7 +30,8 @@ class EventListUseCase
 
     public function getNewestEvents($limit = 6)
     {
-        return Event::orderBy('created_at', 'desc')
+        return Event::whereDate('date', '>=', Carbon::today())
+            ->orderBy('created_at', 'desc')
             ->take($limit)
             ->get();
     }

--- a/app/UseCases/Event/EventListUseCase.php
+++ b/app/UseCases/Event/EventListUseCase.php
@@ -28,6 +28,13 @@ class EventListUseCase
             ->paginate($perPage);
     }
 
+    public function getNewestEvents($limit = 6)
+    {
+        return Event::orderBy('created_at', 'desc')
+            ->take($limit)
+            ->get();
+    }
+
     /**
      * 全てのイベント一覧の取得
      *

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -148,6 +148,8 @@
     "Number of recruits": "人数",
     "Image": "写真",
     "Create a new event.": "新しいイベントを作成します。",
+    "Home": "ホーム",
+    "New events": "新着イベント",
     "Upcoming events": "開催予定のイベント",
     "Event list all": "全てのイベント",
     "Event details": "イベント詳細",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -148,6 +148,8 @@
     "Number of recruits": "人数",
     "Image": "写真",
     "Create a new event.": "新しいイベントを作成します。",
+    "Prev": "前へ",
+    "Next": "次へ",
     "Home": "ホーム",
     "New events": "新着イベント",
     "Upcoming events": "開催予定のイベント",

--- a/public/css/list.css
+++ b/public/css/list.css
@@ -6,6 +6,12 @@
     scrollbar-color: rgba(155, 155, 155, 0.5) transparent;
     padding: 2em auto;
     width: 100%;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+}
+
+#highlighted-event-wrap::-webkit-scrollbar {
+    display: none;
 }
 
 /* 既存のスタイルを新しいクラス名に適用 */
@@ -44,6 +50,31 @@
     overflow: hidden;
     text-overflow: ellipsis;
 }
+
+#carousel-container {
+    position: relative;
+    width: 100%;
+}
+
+.carousel-button {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    border: none;
+    padding: 1em;
+    background-color: rgba(0, 0, 0, 0.5);
+    color: white;
+    cursor: pointer;
+}
+
+#carousel-button-prev {
+    left: 0;
+}
+
+#carousel-button-next {
+    right: 0;
+}
+
 /* --- --- --- --- --- ---*/
 
 /* カードレイアウト部分をラッピングし、

--- a/public/css/list.css
+++ b/public/css/list.css
@@ -1,3 +1,51 @@
+/* 新しいカードレイアウトのラッピング */
+#highlighted-event-wrap {
+    display: flex;
+    overflow-x: auto;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(155, 155, 155, 0.5) transparent;
+    padding: 2em auto;
+    width: 100%;
+}
+
+/* 既存のスタイルを新しいクラス名に適用 */
+.highlighted-event-card {
+    margin: 1em;
+    padding: 0;
+    min-width: calc(100% / 3 - 2em);
+    background: #f0f0f0;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.08);
+    border-radius: 10px;
+}
+
+.highlighted-event-card img {
+    display: block;
+    width: 400px;
+    height: 250px;
+    object-fit: cover;
+    padding: 5px;
+}
+
+.highlighted-event-text {
+    margin: 0;
+    padding: 1em;
+    color: #818181;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.highlighted-event-title {
+    margin: 0.6em 0 0;
+    color: #333;
+    text-align: center;
+    font-size: 1.6em;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+/* --- --- --- --- --- ---*/
+
 /* カードレイアウト部分をラッピングし、
 Flexboxを指定"space-between"で各アイテムを均等に配置し、
 最初と最後のアイテムを端に寄せます。*/

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -24,6 +24,16 @@ html {
     animation: spin 2s linear infinite;
 }
 
+.title-h3 {
+    font-size: 1.2em;
+    line-height: 1.3;
+    letter-spacing: 1px;
+    font-weight: bold;
+    padding: 1rem 2rem;
+    border-left: 5px solid #f6851e;
+    background: #f4f4f4;
+}
+
 .item__header {
     padding: 20px;
     padding-right: 10px;

--- a/public/script/event-carousel.js
+++ b/public/script/event-carousel.js
@@ -1,0 +1,31 @@
+$(document).ready(function () {
+    var scrollAmount = 0;
+
+    $("#carousel-button-prev").click(function () {
+        if (scrollAmount > 0) {
+            scrollAmount -= 200;
+        }
+        $("#highlighted-event-wrap").animate(
+            {
+                scrollLeft: scrollAmount,
+            },
+            500
+        );
+    });
+
+    $("#carousel-button-next").click(function () {
+        if (
+            scrollAmount <
+            $("#highlighted-event-wrap")[0].scrollWidth -
+                $("#highlighted-event-wrap").width()
+        ) {
+            scrollAmount += 200;
+        }
+        $("#highlighted-event-wrap").animate(
+            {
+                scrollLeft: scrollAmount,
+            },
+            500
+        );
+    });
+});

--- a/resources/views/errors/layouts/base.blade.php
+++ b/resources/views/errors/layouts/base.blade.php
@@ -31,7 +31,7 @@
                     <div class="flex">
                         <!-- Logo -->
                         <div class="shrink-0 flex items-center">
-                            <a href="{{ route('index.upcoming') }}">
+                            <a href="{{ route('index.home') }}">
                                 <img src="{{ asset('img/logo.svg') }}" width="50" height="50">
                             </a>
                         </div>

--- a/resources/views/event/list-all.blade.php
+++ b/resources/views/event/list-all.blade.php
@@ -10,6 +10,10 @@
     </x-slot>
 
     <div class="py-12">
-        @include('event.partials.list')
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
+            <div class="p-4 sm:p-8 bg-white shadow sm:rounded-lg">
+                @include('event.partials.list')
+            </div>
+        </div>
     </div>
 </x-app-layout>

--- a/resources/views/event/list-home.blade.php
+++ b/resources/views/event/list-home.blade.php
@@ -15,12 +15,19 @@
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
             <div class="p-4 sm:p-8 bg-white shadow sm:rounded-lg">
+                <div class="flex items-center gap-4">
+                    @if (session('status') === 'event-deleted')
+                        <p x-data="{ show: true }" x-show="show" x-transition x-init="setTimeout(() => show = false, 2000)"
+                            class="text-sm text-gray-600">
+                            {{ __('Deleted the event.') }}</p>
+                    @endif
+                </div>
+
                 @if ($events->currentPage() === 1)
-                    <h3>{{ __('New events') }}</h3>
+                    <h3 class="title-h3">{{ __('New events') }}</h3>
 
                     <div id="carousel-container">
                         <button id="carousel-button-prev" class="carousel-button">{{ __('Prev') }}</button>
-
                         <div id="highlighted-event-wrap">
                             @foreach ($events as $event)
                                 <section class="highlighted-event-card">
@@ -42,7 +49,8 @@
                         <button id="carousel-button-next" class="carousel-button">{{ __('Next') }}</button>
                     </div>
                 @endif
-                <h3>{{ __('Upcoming events') }}</h3>
+                <br />
+                <h3 class="title-h3">{{ __('Upcoming events') }}</h3>
 
                 @include('event.partials.list')
             </div>

--- a/resources/views/event/list-home.blade.php
+++ b/resources/views/event/list-home.blade.php
@@ -29,16 +29,19 @@
                     <div id="carousel-container">
                         <button id="carousel-button-prev" class="carousel-button">{{ __('Prev') }}</button>
                         <div id="highlighted-event-wrap">
-                            @foreach ($events as $event)
+                            @foreach ($newest_events as $newest_event)
                                 <section class="highlighted-event-card">
                                     <a class="card-link" href="#">
                                         <ul>
-                                            <li><a href="{{ route('event.show', $event->id) }}">
-                                                    <h3 class="highlighted-event-title">{{ $event->name }}</h3>
+                                            <li><a href="{{ route('event.show', $newest_event->id) }}">
+                                                    <h3 class="highlighted-event-title">{{ $newest_event->name }}</h3>
                                                     <figure class="card-figure"><img class="event_image mx-auto"
-                                                            src="{{ Storage::url($event->image_path) }}" alt="">
+                                                            src="{{ Storage::url($newest_event->image_path) }}"
+                                                            alt="">
                                                     </figure>
-                                                    <p class="highlighted-event-text">{{ $event->detail }}</p>
+                                                    <p class="highlighted-event-text">{{ $newest_event->detail }}</p>
+                                                    <p class="highlighted-event-text">{{ $newest_event->created_at }}
+                                                    </p>
                                                 </a></li>
                                         </ul>
                                     </a>

--- a/resources/views/event/list-home.blade.php
+++ b/resources/views/event/list-home.blade.php
@@ -19,7 +19,7 @@
                     <h3>{{ __('New events') }}</h3>
 
                     <div id="carousel-container">
-                        <button id="carousel-button-prev" class="carousel-button">Prev</button>
+                        <button id="carousel-button-prev" class="carousel-button">{{ __('Prev') }}</button>
 
                         <div id="highlighted-event-wrap">
                             @foreach ($events as $event)
@@ -39,7 +39,7 @@
                             @endforeach
                         </div>
 
-                        <button id="carousel-button-next" class="carousel-button">Next</button>
+                        <button id="carousel-button-next" class="carousel-button">{{ __('Next') }}</button>
                     </div>
                 @endif
                 <h3>{{ __('Upcoming events') }}</h3>

--- a/resources/views/event/list-home.blade.php
+++ b/resources/views/event/list-home.blade.php
@@ -8,7 +8,7 @@
 <x-app-layout>
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __('Upcoming events') }}
+            {{ __('Home') }}
         </h2>
     </x-slot>
 
@@ -16,7 +16,7 @@
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
             <div class="p-4 sm:p-8 bg-white shadow sm:rounded-lg">
                 @if ($events->currentPage() === 1)
-                    <h3>注目のイベント</h3>
+                    <h3>{{ __('New events') }}</h3>
 
                     <div id="carousel-container">
                         <button id="carousel-button-prev" class="carousel-button">Prev</button>
@@ -42,6 +42,7 @@
                         <button id="carousel-button-next" class="carousel-button">Next</button>
                     </div>
                 @endif
+                <h3>{{ __('Upcoming events') }}</h3>
 
                 @include('event.partials.list')
             </div>

--- a/resources/views/event/list-home.blade.php
+++ b/resources/views/event/list-home.blade.php
@@ -25,33 +25,39 @@
 
                 @if ($events->currentPage() === 1)
                     <h3 class="title-h3">{{ __('New events') }}</h3>
-
-                    <div id="carousel-container">
-                        <button id="carousel-button-prev" class="carousel-button">{{ __('Prev') }}</button>
-                        <div id="highlighted-event-wrap">
-                            @foreach ($newest_events as $newest_event)
-                                <section class="highlighted-event-card">
-                                    <a class="card-link" href="#">
-                                        <ul>
-                                            <li><a href="{{ route('event.show', $newest_event->id) }}">
-                                                    <h3 class="highlighted-event-title">{{ $newest_event->name }}</h3>
-                                                    <figure class="card-figure"><img class="event_image mx-auto"
-                                                            src="{{ Storage::url($newest_event->image_path) }}"
-                                                            alt="">
-                                                    </figure>
-                                                    <p class="highlighted-event-text">{{ $newest_event->detail }}</p>
-                                                    <p class="highlighted-event-text">{{ $newest_event->created_at }}
-                                                    </p>
-                                                </a></li>
-                                        </ul>
-                                    </a>
-                                </section>
-                            @endforeach
+                    @if ($events->isEmpty())
+                        <p>{{ __('No events found.') }}</p>
+                    @else
+                        <div id="carousel-container">
+                            <button id="carousel-button-prev" class="carousel-button">{{ __('Prev') }}</button>
+                            <div id="highlighted-event-wrap">
+                                @foreach ($newest_events as $newest_event)
+                                    <section class="highlighted-event-card">
+                                        <a class="card-link" href="#">
+                                            <ul>
+                                                <li><a href="{{ route('event.show', $newest_event->id) }}">
+                                                        <h3 class="highlighted-event-title">{{ $newest_event->name }}
+                                                        </h3>
+                                                        <figure class="card-figure"><img class="event_image mx-auto"
+                                                                src="{{ Storage::url($newest_event->image_path) }}"
+                                                                alt="">
+                                                        </figure>
+                                                        <p class="highlighted-event-text">{{ $newest_event->detail }}
+                                                        </p>
+                                                        <p class="highlighted-event-text">
+                                                            {{ $newest_event->created_at }}
+                                                        </p>
+                                                    </a></li>
+                                            </ul>
+                                        </a>
+                                    </section>
+                                @endforeach
+                            </div>
+                            <button id="carousel-button-next" class="carousel-button">{{ __('Next') }}</button>
                         </div>
-
-                        <button id="carousel-button-next" class="carousel-button">{{ __('Next') }}</button>
-                    </div>
+                    @endif
                 @endif
+
                 <br />
                 <h3 class="title-h3">{{ __('Upcoming events') }}</h3>
 

--- a/resources/views/event/list-join.blade.php
+++ b/resources/views/event/list-join.blade.php
@@ -10,6 +10,10 @@
     </x-slot>
 
     <div class="py-12">
-        @include('event.partials.list')
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
+            <div class="p-4 sm:p-8 bg-white shadow sm:rounded-lg">
+                @include('event.partials.list')
+            </div>
+        </div>
     </div>
 </x-app-layout>

--- a/resources/views/event/list-organizer.blade.php
+++ b/resources/views/event/list-organizer.blade.php
@@ -10,6 +10,10 @@
     </x-slot>
 
     <div class="py-12">
-        @include('event.partials.list')
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
+            <div class="p-4 sm:p-8 bg-white shadow sm:rounded-lg">
+                @include('event.partials.list')
+            </div>
+        </div>
     </div>
 </x-app-layout>

--- a/resources/views/event/list-upcoming.blade.php
+++ b/resources/views/event/list-upcoming.blade.php
@@ -1,6 +1,10 @@
 @push('css')
     <link rel="stylesheet" href="{{ asset('css/list.css') }}">
 @endpush
+@push('script')
+    <script src="{{ asset('script/event-carousel.js') }}"></script>
+@endpush
+
 <x-app-layout>
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
@@ -14,23 +18,28 @@
                 @if ($events->currentPage() === 1)
                     <h3>注目のイベント</h3>
 
-                    <div id="highlighted-event-wrap">
-                        @foreach ($events as $event)
-                            <section class="highlighted-event-card">
-                                <a class="card-link" href="#">
-                                    <ul>
-                                        <li><a href="{{ route('event.show', $event->id) }}">
-                                                <h3 class="highlighted-event-title">{{ $event->name }}</h3>
-                                                <figure class="card-figure"><img class="event_image mx-auto"
-                                                        src="{{ Storage::url($event->image_path) }}" alt="">
-                                                </figure>
-                                                <p class="highlighted-event-text">{{ $event->detail }}</p>
-                                            </a>
-                                        </li>
-                                    </ul>
-                                </a>
-                            </section>
-                        @endforeach
+                    <div id="carousel-container">
+                        <button id="carousel-button-prev" class="carousel-button">Prev</button>
+
+                        <div id="highlighted-event-wrap">
+                            @foreach ($events as $event)
+                                <section class="highlighted-event-card">
+                                    <a class="card-link" href="#">
+                                        <ul>
+                                            <li><a href="{{ route('event.show', $event->id) }}">
+                                                    <h3 class="highlighted-event-title">{{ $event->name }}</h3>
+                                                    <figure class="card-figure"><img class="event_image mx-auto"
+                                                            src="{{ Storage::url($event->image_path) }}" alt="">
+                                                    </figure>
+                                                    <p class="highlighted-event-text">{{ $event->detail }}</p>
+                                                </a></li>
+                                        </ul>
+                                    </a>
+                                </section>
+                            @endforeach
+                        </div>
+
+                        <button id="carousel-button-next" class="carousel-button">Next</button>
                     </div>
                 @endif
 

--- a/resources/views/event/list-upcoming.blade.php
+++ b/resources/views/event/list-upcoming.blade.php
@@ -12,6 +12,10 @@
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
             <div class="p-4 sm:p-8 bg-white shadow sm:rounded-lg">
+                @if ($events->currentPage() === 1)
+                    <h3>注目のイベント</h3>
+                @endif
+
                 @include('event.partials.list')
             </div>
         </div>

--- a/resources/views/event/list-upcoming.blade.php
+++ b/resources/views/event/list-upcoming.blade.php
@@ -1,7 +1,6 @@
 @push('css')
     <link rel="stylesheet" href="{{ asset('css/list.css') }}">
 @endpush
-
 <x-app-layout>
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
@@ -14,6 +13,25 @@
             <div class="p-4 sm:p-8 bg-white shadow sm:rounded-lg">
                 @if ($events->currentPage() === 1)
                     <h3>注目のイベント</h3>
+
+                    <div id="highlighted-event-wrap">
+                        @foreach ($events as $event)
+                            <section class="highlighted-event-card">
+                                <a class="card-link" href="#">
+                                    <ul>
+                                        <li><a href="{{ route('event.show', $event->id) }}">
+                                                <h3 class="highlighted-event-title">{{ $event->name }}</h3>
+                                                <figure class="card-figure"><img class="event_image mx-auto"
+                                                        src="{{ Storage::url($event->image_path) }}" alt="">
+                                                </figure>
+                                                <p class="highlighted-event-text">{{ $event->detail }}</p>
+                                            </a>
+                                        </li>
+                                    </ul>
+                                </a>
+                            </section>
+                        @endforeach
+                    </div>
                 @endif
 
                 @include('event.partials.list')

--- a/resources/views/event/list-upcoming.blade.php
+++ b/resources/views/event/list-upcoming.blade.php
@@ -10,6 +10,10 @@
     </x-slot>
 
     <div class="py-12">
-        @include('event.partials.list')
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
+            <div class="p-4 sm:p-8 bg-white shadow sm:rounded-lg">
+                @include('event.partials.list')
+            </div>
+        </div>
     </div>
 </x-app-layout>

--- a/resources/views/event/partials/list.blade.php
+++ b/resources/views/event/partials/list.blade.php
@@ -1,20 +1,13 @@
-<div class="flex items-center gap-4">
-    @if (session('status') === 'event-deleted')
-        <p x-data="{ show: true }" x-show="show" x-transition x-init="setTimeout(() => show = false, 2000)" class="text-sm text-gray-600">
-            {{ __('Deleted the event.') }}</p>
-    @endif
-</div>
 @if ($events->isEmpty())
     <p>{{ __('No events found.') }}</p>
 @else
     <div id="cardlayout-wrap">
-        <!--カードレイアウトをラッピング -->
         @foreach ($events as $event)
             <section class="card-list">
                 <a class="card-link" href="#">
                     <ul>
                         <li><a href="{{ route('event.show', $event->id) }}">
-                                <h3 class="card-title">{{ $event->name }}</h3>
+                                <h4 class="card-title">{{ $event->name }}</h4>
                                 <figure class="card-figure"><img class="event_image mx-auto"
                                         src="{{ Storage::url($event->image_path) }}" alt="">
                                 </figure>
@@ -26,7 +19,6 @@
             </section>
         @endforeach
     </div>
-    <!--カードレイアウトをラッピング -->
 @endif
 <br />
 {{ $events->links() }}

--- a/resources/views/event/partials/list.blade.php
+++ b/resources/views/event/partials/list.blade.php
@@ -1,36 +1,32 @@
-<div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
-    <div class="p-4 sm:p-8 bg-white shadow sm:rounded-lg">
-        <div class="flex items-center gap-4">
-            @if (session('status') === 'event-deleted')
-                <p x-data="{ show: true }" x-show="show" x-transition x-init="setTimeout(() => show = false, 2000)"
-                    class="text-sm text-gray-600">{{ __('Deleted the event.') }}</p>
-            @endif
-        </div>
-        @if ($events->isEmpty())
-            <p>{{ __('No events found.') }}</p>
-        @else
-            <div id="cardlayout-wrap">
-                <!--カードレイアウトをラッピング -->
-                @foreach ($events as $event)
-                    <section class="card-list">
-                        <a class="card-link" href="#">
-                            <ul>
-                                <li><a href="{{ route('event.show', $event->id) }}">
-                                        <h3 class="card-title">{{ $event->name }}</h3>
-                                        <figure class="card-figure"><img class="event_image mx-auto"
-                                                src="{{ Storage::url($event->image_path) }}" alt="">
-                                        </figure>
-                                        <p class="card-text-tax">{{ $event->detail }}</p>
-                                    </a>
-                                </li>
-                            </ul>
-                        </a>
-                    </section>
-                @endforeach
-            </div>
-            <!--カードレイアウトをラッピング -->
-        @endif
-        <br />
-        {{ $events->links() }}
-    </div>
+<div class="flex items-center gap-4">
+    @if (session('status') === 'event-deleted')
+        <p x-data="{ show: true }" x-show="show" x-transition x-init="setTimeout(() => show = false, 2000)" class="text-sm text-gray-600">
+            {{ __('Deleted the event.') }}</p>
+    @endif
 </div>
+@if ($events->isEmpty())
+    <p>{{ __('No events found.') }}</p>
+@else
+    <div id="cardlayout-wrap">
+        <!--カードレイアウトをラッピング -->
+        @foreach ($events as $event)
+            <section class="card-list">
+                <a class="card-link" href="#">
+                    <ul>
+                        <li><a href="{{ route('event.show', $event->id) }}">
+                                <h3 class="card-title">{{ $event->name }}</h3>
+                                <figure class="card-figure"><img class="event_image mx-auto"
+                                        src="{{ Storage::url($event->image_path) }}" alt="">
+                                </figure>
+                                <p class="card-text-tax">{{ $event->detail }}</p>
+                            </a>
+                        </li>
+                    </ul>
+                </a>
+            </section>
+        @endforeach
+    </div>
+    <!--カードレイアウトをラッピング -->
+@endif
+<br />
+{{ $events->links() }}

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -5,15 +5,15 @@
             <div class="flex">
                 <!-- Logo -->
                 <div class="shrink-0 flex items-center">
-                    <a href="{{ route('index.upcoming') }}">
+                    <a href="{{ route('index.home') }}">
                         <img src="{{ asset('img/logo.svg') }}" width="50" height="50">
                     </a>
                 </div>
 
                 <!-- Navigation Links -->
                 <div class="hidden space-x-8 sm:-my-px sm:ml-10 sm:flex">
-                    <x-nav-link :href="route('index.upcoming')" :active="request()->routeIs('index.upcoming')">
-                        {{ __('Upcoming events') }}
+                    <x-nav-link :href="route('index.home')" :active="request()->routeIs('index.home')">
+                        {{ __('Home') }}
                     </x-nav-link>
                     <x-nav-link :href="route('index.all')" :active="request()->routeIs('index.all')">
                         {{ __('Event list all') }}
@@ -100,8 +100,8 @@
     <!-- Responsive Navigation Menu -->
     <div :class="{ 'block': open, 'hidden': !open }" class="hidden sm:hidden">
         <div class="pt-2 pb-3 space-y-1">
-            <x-responsive-nav-link :href="route('index.upcoming')" :active="request()->routeIs('index.upcoming')">
-                {{ __('Upcoming events') }}
+            <x-responsive-nav-link :href="route('index.home')" :active="request()->routeIs('index.home')">
+                {{ __('Home') }}
             </x-responsive-nav-link>
             <x-responsive-nav-link :href="route('index.all')" :active="request()->routeIs('index.all')">
                 {{ __('Event list all') }}

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -22,7 +22,7 @@
         <div class="buttons">
             @if (Route::has('login'))
                 @auth
-                    <a href="{{ route('index.upcoming') }}">{{ __('Start') }}</a>
+                    <a href="{{ route('index.home') }}">{{ __('Start') }}</a>
                 @else
                     <a href="{{ route('login') }}">{{ __('Login') }}</a>
                     @if (Route::has('register'))

--- a/routes/event.php
+++ b/routes/event.php
@@ -11,11 +11,6 @@ use App\Http\Controllers\Profile\ProfileController;
 use Illuminate\Support\Facades\Route;
 
 Route::middleware(['auth', 'verified', 'disabled'])->group(function () {
-    // プロフィール編集画面
-    Route::get('/profile/edit', [ProfileController::class, 'edit'])->name('profile.edit');
-    Route::patch('/profile/update', [ProfileController::class, 'update'])->name('profile.update');
-    Route::delete('/profile/delete', [ProfileController::class, 'destroy'])->name('profile.destroy');
-
     // イベント関連
     Route::get('/event/create',  [EventCreateController::class, 'create'])->name('event.create');
     Route::patch('/event/store', [EventCreateController::class, 'store'])->name('event.store');
@@ -35,5 +30,5 @@ Route::middleware(['auth', 'verified', 'disabled'])->group(function () {
     Route::get('/events/all', [EventListController::class, 'indexAll'])->name('index.all');
     Route::get('/events/join', [EventListController::class, 'indexJoin'])->name('index.join');
     Route::get('/events/organizer', [EventListController::class, 'indexOrganizer'])->name('index.organizer');
-    Route::get('/upcoming', [EventListController::class, 'indexUpcoming'])->name('index.upcoming');
+    Route::get('/home', [EventListController::class, 'indexHome'])->name('index.home');
 });


### PR DESCRIPTION
## 対応したISSUE
- close #ISSUE_NUMBER

## 概要
- urlの変更: `/upcoming` → `/home`
- 表示内容の変更: 新しく作成された順にイベントを横並び（カルーセル）に表示
※ イベント開催日を過ぎたものは非表示
※ 「開催予定のイベント」は開催日が遠い順に並んでいる（変更なし）

## リンク
-

## レビュー箇所
- [x] レビューしてほしい箇所

## スクリーンショット
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="https://github.com/SymbaX/symbax/assets/33868170/29988f66-b07d-473d-9f08-c134436292c8" width="300" />


<!-- 変更前のスクリーンショットは可能であれば貼り付ける --> 
