### PR TITLE
新規イベント作成のリンクをFABに変更

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -116,7 +116,7 @@ button[disabled] {
 }
 
 .create_fab {
-    background-color: #ff4081;
+    background-color: #f5851f;
     width: 56px;
     height: 56px;
     border-radius: 50%;
@@ -135,7 +135,7 @@ button[disabled] {
 }
 
 .create_fab:not(.bg-gray-400):hover {
-    background-color: #e91e63;
+    background-color: #f48f31;
 }
 
 .create_fab.bg-gray-400 {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -115,6 +115,33 @@ button[disabled] {
     margin-bottom: 10px;
 }
 
+.create_fab {
+    background-color: #ff4081;
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    position: fixed;
+    bottom: 16px;
+    right: 16px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 24px;
+    color: white;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+    transition: background-color 0.3s;
+    text-decoration: none;
+    z-index: 1000;
+}
+
+.create_fab:not(.bg-gray-400):hover {
+    background-color: #e91e63;
+}
+
+.create_fab.bg-gray-400 {
+    cursor: not-allowed;
+}
+
 .label-with-tooltip {
     display: flex;
     align-items: center;

--- a/resources/views/event/list-all.blade.php
+++ b/resources/views/event/list-all.blade.php
@@ -16,4 +16,6 @@
             </div>
         </div>
     </div>
+
+    <a href="{{ route('event.create') }}" class="create_fab">+</a>
 </x-app-layout>

--- a/resources/views/event/list-home.blade.php
+++ b/resources/views/event/list-home.blade.php
@@ -58,4 +58,5 @@
 
             </div>
         </div>
+        <a href="{{ route('event.create') }}" class="create_fab">+</a>
 </x-app-layout>

--- a/resources/views/event/list-organizer.blade.php
+++ b/resources/views/event/list-organizer.blade.php
@@ -16,4 +16,5 @@
             </div>
         </div>
     </div>
+    <a href="{{ route('event.create') }}" class="create_fab">+</a>
 </x-app-layout>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -41,10 +41,6 @@
                     </x-slot>
 
                     <x-slot name="content">
-                        <x-dropdown-link :href="route('event.create')">
-                            {{ __('Create event') }}
-                        </x-dropdown-link>
-
                         <x-dropdown-link :href="route('index.join')">
                             {{ __('Join event') }}
                         </x-dropdown-link>
@@ -116,10 +112,6 @@
             </div>
 
             <div class="mt-3 space-y-1">
-                <x-responsive-nav-link :href="route('event.create')">
-                    {{ __('Create event') }}
-                </x-responsive-nav-link>
-
                 <x-responsive-nav-link :href="route('index.join')">
                     {{ __('Join event') }}
                 </x-responsive-nav-link>


### PR DESCRIPTION
## 対応したISSUE
- close #322

## 概要
以下のページに「新規イベント」ページへ遷移するFABを配置
- ホーム
- 全てのイベント
- 主催イベント

## リンク
-

## レビュー箇所
- [x] FABが表示されているか

## スクリーンショット
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="https://github.com/SymbaX/symbax/assets/33868170/09a97474-0ecc-4617-a41e-380ec9f2fd4a" width="300" />


<!-- 変更前のスクリーンショットは可能であれば貼り付ける --> 
