### PR TITLE
OGP一括生成処理

### DIFF
--- a/app/Http/Controllers/Admin/TitleImageCreateController.php
+++ b/app/Http/Controllers/Admin/TitleImageCreateController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\UseCases\Admin\TitleImageCreateUseCase;
+
+/**
+ * タイトルイメージ生成のコントローラークラス
+ */
+class TitleImageCreateController extends Controller
+{
+    /**
+     * タイトルイメージ生成のビジネスロジックを提供するユースケース
+     *
+     * @var TitleImageCreateUseCase 使用するUseCaseインスタンス
+     */
+    private $titleImageCreateUseCase;
+
+    /**
+     * TitleImageCreateControllerのコンストラクタ
+     *
+     * 使用するユースケースをインジェクション（注入）します。
+     *
+     * @param TitleImageCreateUseCase $titleImageCreateUseCase タイトルイメージ生成のユースケース
+     */
+    public function __construct(TitleImageCreateUseCase $titleImageCreateUseCase)
+    {
+        $this->titleImageCreateUseCase = $titleImageCreateUseCase;
+    }
+
+    /* =================== 以下メインの処理 =================== */
+
+    /**
+     * タイトルイメージを生成するメソッド
+     *
+     * タイトルイメージを生成する処理を呼び出します。
+     *
+     * @return View 管理者ダッシュボードのビュー
+     */
+    public function createImage()
+    {
+        $this->titleImageCreateUseCase->createImage();
+
+        // Viewを返す
+        return view('admin.dashboard');
+    }
+}

--- a/app/UseCases/Admin/TitleImageCreateUseCase.php
+++ b/app/UseCases/Admin/TitleImageCreateUseCase.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\UseCases\Admin;
+
+use App\UseCases\OperationLog\OperationLogUseCase;
+
+/**
+ * タイトルイメージ生成のユースケースクラス
+ *
+ * タイトルイメージ生成の動作やログ記録に関連する処理を担当します。
+ */
+class TitleImageCreateUseCase
+{
+    /**
+     * 操作ログを保存するためのビジネスロジックを提供するユースケース
+     * このユースケースを利用して、システムの操作に関するログの記録処理を行います。
+     *
+     * @var OperationLogUseCase
+     */
+    private $operationLogUseCase;
+
+    /**
+     * TitleImageCreateUseCaseのコンストラクタ
+     *
+     * 使用するユースケースをインジェクション（注入）します。
+     *
+     * @param OperationLogUseCase $operationLogUseCase 操作ログに関するユースケース
+     */
+    public function __construct(OperationLogUseCase $operationLogUseCase)
+    {
+        $this->operationLogUseCase = $operationLogUseCase;
+    }
+
+    /* =================== 以下メインの処理 =================== */
+
+    /**
+     * タイトルイメージ生成の処理を行います。
+     *
+     * タイトルイメージを一括で生成する処理を行います。
+     */
+    public function createImage()
+    {
+        return;
+    }
+}

--- a/app/UseCases/Admin/TitleImageCreateUseCase.php
+++ b/app/UseCases/Admin/TitleImageCreateUseCase.php
@@ -2,7 +2,9 @@
 
 namespace App\UseCases\Admin;
 
+use App\Models\Event;
 use App\UseCases\OperationLog\OperationLogUseCase;
+use Intervention\Image\Facades\Image;
 
 /**
  * タイトルイメージ生成のユースケースクラス
@@ -40,6 +42,39 @@ class TitleImageCreateUseCase
      */
     public function createImage()
     {
+        // イベントを取得する
+        $events =  Event::all();
+
+        foreach ($events as $event) {
+            $this->createEventOGP($event);
+        }
+
         return;
+    }
+
+    /**
+     * イベントのOGPを作成する
+     *
+     * @param Event $event
+     * @return void
+     */
+    private function createEventOGP(Event $event)
+    {
+        // OGPを生成
+        $path = public_path('img/base.png');
+        $img = Image::make($path);
+
+        // 画像にテキストを入れる。
+        $img->text(preg_replace('/[\x{10000}-\x{10FFFF}]/u', '', $event->name), 60, 220, function ($font) {
+            $font->file(public_path('fonts/NotoSansJP-SemiBold.ttf'));
+            $font->size(54);
+            $font->color("#000");
+            $font->align("left");
+            $font->valign("top");
+        });
+
+        // OGP画像を保存
+        $save_path = storage_path('app/public/event-titles/ogp_' . $event->id . '.png');
+        $img->save($save_path);
     }
 }

--- a/app/UseCases/Admin/TitleImageCreateUseCase.php
+++ b/app/UseCases/Admin/TitleImageCreateUseCase.php
@@ -49,6 +49,17 @@ class TitleImageCreateUseCase
             $this->createEventOGP($event);
         }
 
+        // 操作ログを保存
+        $this->operationLogUseCase->store([
+            'detail' => null,
+            'user_id' => null,
+            'target_event_id' => null,
+            'target_user_id' => null,
+            'target_topic_id' => null,
+            'action' => 'event-title-image-create',
+            'ip' => request()->ip(),
+        ]);
+
         return;
     }
 

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -227,5 +227,6 @@
     "Deadline has passed.": "締切日を過ぎています。",
     "Close": "閉じる",
     "You will be automatically redirected to the event details page.": "自動的にイベント詳細ページに移動します。",
-    "If it does not move after waiting for a while, click here.": "しばらく待っても移動しない場合はこちらをクリックしてください。"
+    "If it does not move after waiting for a while, click here.": "しばらく待っても移動しない場合はこちらをクリックしてください。",
+    "Generate title images in batches": "タイトルイメージを一括で生成する"
 }

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -19,8 +19,25 @@
                     <a href="{{ route('admin.mail') }}" class="text-blue-500 hover:text-blue-700">
                         {{ __('Mail') }}</a>
                     <br />
+                    <a href="{{ route('admin.title-image') }}" class="text-blue-500 hover:text-blue-700 link_confirm">
+                        {{ __('Generate title images in batches') }}</a>
+                    <br />
                 </div>
             </div>
         </div>
     </div>
 </x-app-layout>
+
+<script>
+    jQuery(function($) {
+        const linkConfirms = $('.link_confirm');
+        if (linkConfirms.length) {
+            linkConfirms.click(function(event) {
+                const resultConfirm = confirm('この操作はOGPをあとから生成する機能です。');
+                if (!resultConfirm) {
+                    event.preventDefault();
+                }
+            })
+        }
+    });
+</script>

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\Admin\ListUsersController;
 use App\Http\Controllers\Admin\UserUpdateController;
 use App\Http\Controllers\Admin\ListOperationLogsController;
 use App\Http\Controllers\Admin\MailSendController;
+use App\Http\Controllers\Admin\TitleImageCreateController;
 use Illuminate\Support\Facades\Route;
 
 Route::middleware(['auth', 'verified', 'admin', 'disabled'])->group(function () {
@@ -17,4 +18,6 @@ Route::middleware(['auth', 'verified', 'admin', 'disabled'])->group(function () 
 
     Route::get('/admin/mail', [MailSendController::class, 'showMailForm'])->name('admin.mail');
     Route::patch('/admin/mail', [MailSendController::class, 'sendMail'])->name('admin.mail.send');
+
+    Route::get('/admin/create/title-image', [TitleImageCreateController::class, 'createImage'])->name('admin.title-image');
 });


### PR DESCRIPTION
## 対応したISSUE
- 

## 概要
- OGP対応前( a42d31f8299e6b7e01568ed1b6c9caf811a0a73d )に作成されたイベントはOGP画像が生成されていないため
あとから一括で生成する処理を管理者向けに追加します。

## レビュー優先度
- [ ] 🚀 すぐに
- [ ] 🚗 今日中に
- [x] 🚶🏻 ３日以内に
- [ ] 🐢 余裕のある時に

## レビュー箇所
- [ ] レビューしてほしい箇所

## スクリーンショット
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## リンク
-

<!-- 変更前のスクリーンショットは可能であれば貼り付ける --> 
