### PR TITLE
ユーザーの退会処理を論理削除にする

### DIFF
--- a/app/Http/Controllers/Event/EventSearchController.php
+++ b/app/Http/Controllers/Event/EventSearchController.php
@@ -21,6 +21,11 @@ class EventSearchController extends Controller
 
         $query = Event::query();
 
+        // 主催者が論理削除されていないイベントのみを取得
+        $query->whereHas('organizer', function ($q) {
+            $q->whereNull('deleted_at');
+        });
+
         if ($selectedCategoryId == "All Categories") {
             $query->where('detail', 'LIKE', "%{$keyword}%");
         } elseif (!empty($keyword)) {

--- a/app/Http/Requests/Auth/UserRegistrationRequest.php
+++ b/app/Http/Requests/Auth/UserRegistrationRequest.php
@@ -21,7 +21,13 @@ class UserRegistrationRequest extends FormRequest
                 'not_in:all'
             ],
             'email' => [
-                'required', 'string', 'email', 'max:255', Rule::unique('users'), 'regex:/^[a-zA-Z0-9][^@]+@g\.neec\.ac\.jp$/', 'regex:/^(?!.*[+]).*$/'
+                'required',
+                'string',
+                'email',
+                'max:255',
+                'unique:users,email,NULL,id,deleted_at,NULL',
+                'regex:/^[a-zA-Z0-9][^@]+@g\.neec\.ac\.jp$/',
+                'regex:/^(?!.*[+]).*$/'
             ],
             'password' => ['required', 'confirmed', Password::defaults()],
             'college' => ['required', 'exists:colleges,id'],

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -10,6 +10,7 @@ use Laravel\Sanctum\HasApiTokens;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 /**
  * ユーザーモデルクラス
@@ -20,6 +21,7 @@ class User extends Authenticatable implements MustVerifyEmail
 {
     use Notifiable;
     use HasApiTokens, HasFactory, Notifiable;
+    use SoftDeletes;
 
     /**
      * フィルアブル属性の定義
@@ -54,6 +56,14 @@ class User extends Authenticatable implements MustVerifyEmail
         'email_verified_at' => 'datetime',
         'password' => 'hashed',
     ];
+
+    /**
+     * 日付を格納する属性の定義
+     *
+     * @var array
+     */
+    protected $dates = ['deleted_at'];
+
 
     public function college()
     {

--- a/app/UseCases/Admin/ListUsersUseCase.php
+++ b/app/UseCases/Admin/ListUsersUseCase.php
@@ -16,14 +16,14 @@ class ListUsersUseCase
     /**
      * 操作ログを保存するためのビジネスロジックを提供するユースケース
      * このユースケースを利用して、システムの操作に関するログの記録処理を行います。
-     * 
+     *
      * @var OperationLogUseCase
      */
     private $operationLogUseCase;
 
     /**
      * ListUsersUseCaseのコンストラクタ
-     * 
+     *
      * 使用するユースケースをインジェクション（注入）します。
      *
      * @param OperationLogUseCase $operationLogUseCase 操作ログに関するユースケース
@@ -42,7 +42,7 @@ class ListUsersUseCase
      */
     public function fetchUsersData()
     {
-        $users = User::paginate(10);
+        $users = User::withTrashed()->paginate(10);
         $colleges = College::all();
         $departments = Department::all();
         $roles = Role::all();

--- a/app/UseCases/Event/EventDetailUseCase.php
+++ b/app/UseCases/Event/EventDetailUseCase.php
@@ -55,6 +55,13 @@ class EventDetailUseCase
 
         $category_name = EventCategories::where('id', $event->category)->value('name');
 
+        // 主催者が論理削除されている場合は、エラー
+        $user = User::where('id', $event->organizer_id)->whereNull('deleted_at')->first();
+        if (!$user) {
+            abort(404, 'The organizer of this event has been removed.');
+        }
+
+
         // セッションにイベントIDとトークンを保存
         session()->put('status_change_event_id', $id);
         session()->put('status_change_token', str()->uuid()->toString());

--- a/app/UseCases/Event/EventListUseCase.php
+++ b/app/UseCases/Event/EventListUseCase.php
@@ -27,6 +27,9 @@ class EventListUseCase
     {
         return Event::whereDate('date', '>=', Carbon::today())
             ->where('is_deleted', false)
+            ->whereHas('organizer', function ($query) {
+                $query->whereNull('deleted_at');
+            })
             ->orderBy('date', 'desc')
             ->paginate($per_page);
     }
@@ -35,6 +38,9 @@ class EventListUseCase
     {
         return Event::whereDate('date', '>=', Carbon::today())
             ->where('is_deleted', false)
+            ->whereHas('organizer', function ($query) {
+                $query->whereNull('deleted_at');
+            })
             ->orderBy('created_at', 'desc')
             ->take($limit)
             ->get();
@@ -51,6 +57,9 @@ class EventListUseCase
     public function getAllEvents($per_page = 12)
     {
         return Event::where('is_deleted', false)
+            ->whereHas('organizer', function ($query) {
+                $query->whereNull('deleted_at');
+            })
             ->orderBy('date', 'desc')
             ->paginate($per_page);
     }
@@ -70,6 +79,9 @@ class EventListUseCase
             ->whereDate('date', '>=', Carbon::today())
             ->where('is_deleted', false)
             ->where('status', '!=', 'rejected')
+            ->whereHas('organizer', function ($query) {
+                $query->whereNull('deleted_at');
+            })
             ->orderBy('date', 'desc')
             ->paginate($per_page);
     }
@@ -87,6 +99,9 @@ class EventListUseCase
     {
         return $user->organizedEvents()
             ->where('is_deleted', false)
+            ->whereHas('organizer', function ($query) {
+                $query->whereNull('deleted_at');
+            })
             ->orderBy('date', 'desc')
             ->paginate($per_page);
     }

--- a/app/UseCases/Event/EventStatusUseCase.php
+++ b/app/UseCases/Event/EventStatusUseCase.php
@@ -24,23 +24,23 @@ class EventStatusUseCase
 {
     /**
      * 操作ログを保存するためのビジネスロジックを提供するユースケース
-     * 
+     *
      * @var OperationLogUseCase
      */
     private $operationLogUseCase;
 
     /**
      * イベントオーガナイザーを確認するためのサービス
-     * 
+     *
      * @var CheckEventOrganizerService
      */
     private $checkEventOrganizerService;
 
     /**
      * EventStatusUseCaseのコンストラクタ
-     * 
+     *
      * 使用するユースケースとサービスをインジェクション（注入）します。
-     * 
+     *
      * @param OperationLogUseCase $operationLogUseCase 操作ログに関するユースケース
      * @param CheckEventOrganizerService $checkEventOrganizerService イベントオーガナイザーを確認するためのサービス
      */
@@ -202,6 +202,12 @@ class EventStatusUseCase
         // 参加者が存在しない場合はエラー
         if (!$participant) {
             return 'not-change-status';
+        }
+
+        // ユーザーが論理削除されている場合はエラー
+        $user = User::where('id', $user_id)->whereNull('deleted_at')->first();
+        if (!$user) {
+            return 'no-change';
         }
 
         $originalStatus = $participant->status; // 変更前のステータスを保存

--- a/database/migrations/2023_10_11_211536_add_column_soft_deletes_users_table.php
+++ b/database/migrations/2023_10_11_211536_add_column_soft_deletes_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->softDeletes();
+            $table->dropUnique('users_email_unique');
+            $table->unique(['email', 'deleted_at'], 'users_email_unique');;
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('deleted_at');
+            $table->dropUnique('users_email_unique');
+            $table->unique('email', 'users_email_unique');
+        });
+    }
+};

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -232,5 +232,6 @@
     "Keyword Search": "キーワード検索",
     "You will be automatically redirected to the event details page.": "自動的にイベント詳細ページに移動します。",
     "If it does not move after waiting for a while, click here.": "しばらく待っても移動しない場合はこちらをクリックしてください。",
-    "Generate title images in batches": "タイトルイメージを一括で生成する"
+    "Generate title images in batches": "タイトルイメージを一括で生成する",
+    "Deleted": "削除済み"
 }

--- a/resources/views/admin/users-list.blade.php
+++ b/resources/views/admin/users-list.blade.php
@@ -57,14 +57,27 @@
 
                                     {{ $user->email }}
                                 </td>
-                                <td data-label="{{ __('Role') }}">{{ $user->role->name }}</td>
+                                <td data-label="{{ __('Role') }}">
+                                    @if ($user->deleted_at == null)
+                                        {{ $user->role->name }}
+                                    @else
+                                        {{ $user->role->name }}<br />
+                                        <span class="text-red-500"> {{ __('Deleted') }}</span>
+                                    @endif
+                                </td>
                                 <td data-label="{{ __('College') }}">{{ $user->college->name }}</td>
                                 <td data-label="{{ __('Department') }}">{{ $user->department->name }}</td>
                                 <td data-label="{{ __('Created At') }}">{{ $user->created_at }}</td>
                                 <td data-label="{{ __('Edit') }}">
-                                    <x-primary-button
-                                        onclick="openEditModal('{{ $user->id }}','{{ $user->login_id }}','{{ $user->name }}','{{ $user->email }}','{{ $user->college_id }}', '{{ $user->department_id }}', '{{ $user->role_id }}')">
-                                        {{ __('Edit') }}</x-primary-button>
+                                    @if ($user->deleted_at == null)
+                                        <x-primary-button
+                                            onclick="openEditModal('{{ $user->id }}','{{ $user->login_id }}','{{ $user->name }}','{{ $user->email }}','{{ $user->college_id }}', '{{ $user->department_id }}', '{{ $user->role_id }}')">
+                                            {{ __('Edit') }}</x-primary-button>
+                                    @else
+                                        <x-primary-button disabled>
+                                            {{ __('Edit') }}
+                                        </x-primary-button>
+                                    @endif
                                 </td>
                             </tr>
                         @endforeach

--- a/resources/views/components/primary-button.blade.php
+++ b/resources/views/components/primary-button.blade.php
@@ -1,4 +1,5 @@
 <button
-    {{ $attributes->merge(['type' => 'submit', 'class' => 'inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 focus:bg-gray-700 active:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150']) }}>
+    {{ $attributes->merge(['type' => 'submit', 'class' => 'inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 focus:bg-gray-700 active:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150' . ($attributes->get('disabled') ? ' opacity-50 cursor-not-allowed' : '')]) }}
+    {{ $attributes->get('disabled') ? 'disabled' : '' }}>
     {{ $slot }}
 </button>

--- a/resources/views/event/community.blade.php
+++ b/resources/views/event/community.blade.php
@@ -68,13 +68,18 @@
                                     src="{{ isset($topic->user->profile_photo_path) ? Storage::url($topic->user->profile_photo_path) : asset('img/default-user.png') }}"
                                     alt="" class="w-10 h-10 rounded-full object-cover border-none bg-gray-200">
                                 <div class="user-info">
-                                    <div>{{ $topic->user->name }} <span
-                                            class="login-id">{{ $topic->user->login_id }}</span></div>
+                                    @if ($topic->user)
+                                        <div>{{ $topic->user->name }} <span
+                                                class="login-id">{{ $topic->user->login_id }}</span></div>
+                                    @else
+                                        <div>{{ __('Unknown') }} <span class="login-id">{{ __('Unknown') }}</span>
+                                        </div>
+                                    @endif
                                 </div>
                             </div>
                             <div class="comment-detail-wrapper">
                                 <div class="comment-detail">
-                                    @if ($topic->is_deleted == true)
+                                    @if ($topic->is_deleted == true or $topic->user == null)
                                         <div class="p-2 is_deleted"><i>{{ __('This post has been deleted') }}</i></div>
                                     @else
                                         <div class="p-2">{{ $topic->content }}</div>


### PR DESCRIPTION
## 対応したISSUE
- なし

## 概要
- ユーザーが退会処理を実行した場合に物理削除ではなく
論理削除するように変更しました。
- **この変更には他のビジネスロジックを多く修正しています。
PRをマージする前に詳細なレビュー、テストが必要です。** 

## レビュー優先度
- [ ] 🚀 すぐに
- [ ] 🚗 今日中に
- [ ] 🚶🏻 ３日以内に
- [x] 🐢 余裕のある時に

## レビュー箇所
- [ ] テストする

## スクリーンショット
※ UIに変更はありません

## リンク
-

<!-- 変更前のスクリーンショットは可能であれば貼り付ける --> 
